### PR TITLE
feat(alias): support per project alias that overrides common alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,14 @@ program
 
 program.on('command:*', async (args) => {
   const alias = args.shift();
-  const cmd = conf.get(`alias:${alias}`);
+  let cmd = conf.get(`alias:${alias}`);
+  const pkg = path.join(process.cwd(), '/package.json');
+
+  // package.json alias overrides the common alias
+  if (fs.existsSync(pkg)) {
+    const {gitflow: {alias: aliases = {}} = {}} = require(pkg);
+    cmd = aliases[alias] || cmd;
+  }
 
   try {
     if (!cmd) {


### PR DESCRIPTION
closes #28 

#### example

>  package.json

```js
"gitflow": {
  "alias": {
    "uptrans": "git checkout master -- language && git commit -m 'chore(lang): merge language from master'"
  }
}
```

##### usage
```sh
gitflow uptrans
```